### PR TITLE
Fix `DD_TRACE_ENABLED` handling to respect the doc

### DIFF
--- a/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
+++ b/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
@@ -99,8 +99,15 @@ object DatadogAPM extends AutoPlugin {
             // We have to check `datadogApmEnabled` to enable profiling because if we activate the profiling but deactivate the APM, the APM will start anyway.
             // I'm clearly not an expert in Bash... At least, it's explicit...
             s"""
-               |if [ "$${DD_TRACE_ENABLED}" == "true" ]; then
-               |  export __ENABLE_TRACES__=true
+               |if [ -z "$${DD_TRACE_ENABLED}" ]; then # See https://stackoverflow.com/a/39296583/2431728
+               |  if [ "$${DD_TRACE_ENABLED}" == "true" ]; then
+               |    export __ENABLE_TRACES__=true
+               |  elif [ "$${DD_TRACE_ENABLED}" == "false" ]; then
+               |    export __ENABLE_TRACES__=false
+               |  else
+               |    echo "Invalid value for DD_TRACE_ENABLED: $${DD_TRACE_ENABLED}. Must be `true` or `false`"
+               |    exit 1
+               |  fi
                |else
                |  export __ENABLE_TRACES__=${datadogApmEnabled.value}
                |fi


### PR DESCRIPTION
Only use `datadogApmEnabled` value if the `DD_TRACE_ENABLED` envvar is not set

For details, see https://github.com/guizmaii/sbt-datadog/pull/105#issuecomment-1793670215